### PR TITLE
Add Supabase login example

### DIFF
--- a/Mojo/ContentView.swift
+++ b/Mojo/ContentView.swift
@@ -1,17 +1,75 @@
-//
-//  ContentView.swift
-//  Mojo
-//
-//  Created by Tyler Bullock on 6/15/25.
-//
-
+import Supabase
 import SwiftUI
 
 struct ContentView: View {
+    @State private var todos: [Todo] = []
+    @State private var email: String = ""
+    @State private var password: String = ""
+    @State private var isLoggedIn: Bool = false
+    @State private var errorMessage: String?
+
     var body: some View {
-        NavigationView {
-            HabitTracker()
-                .navigationTitle("Mojo")
+        NavigationStack {
+            if isLoggedIn {
+                List(todos) { todo in
+                    Text(todo.title)
+                }
+                .navigationTitle("Todos")
+                .toolbar {
+                    Button("Logout", action: signOut)
+                }
+                .task {
+                    await loadTodos()
+                }
+            } else {
+                VStack(spacing: 16) {
+                    TextField("Email", text: $email)
+                        .autocapitalization(.none)
+                        .textFieldStyle(.roundedBorder)
+                    SecureField("Password", text: $password)
+                        .textFieldStyle(.roundedBorder)
+                    if let errorMessage {
+                        Text(errorMessage)
+                            .foregroundColor(.red)
+                    }
+                    Button("Sign In", action: signIn)
+                        .buttonStyle(.borderedProminent)
+                }
+                .padding()
+                .navigationTitle("Login")
+            }
+        }
+    }
+
+    private func loadTodos() async {
+        do {
+            todos = try await supabase.from("todos").select().execute().value
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func signIn() {
+        Task {
+            do {
+                try await supabase.auth.signIn(email: email, password: password)
+                isLoggedIn = true
+                errorMessage = nil
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func signOut() {
+        Task {
+            do {
+                try await supabase.auth.signOut()
+                isLoggedIn = false
+                todos = []
+            } catch {
+                errorMessage = error.localizedDescription
+            }
         }
     }
 }

--- a/Mojo/Supabase.swift
+++ b/Mojo/Supabase.swift
@@ -1,9 +1,61 @@
 import Foundation
-import Supabase
 
-// Configure the Supabase client used throughout the app.
-// Replace the placeholder key with your project's anon key.
-let supabase = SupabaseClient(
-    supabaseURL: URL(string: "https://utlrtdwxjyjmlpzbyfgx.supabase.co")!,
-    supabaseKey: "YOUR_SUPABASE_ANON_KEY"
-)
+/// Minimal helper for interacting with Supabase using raw HTTP requests.
+/// This avoids requiring the `Supabase` Swift package so the project builds
+/// without additional dependencies.
+enum SupabaseAPI {
+    static let url = URL(string: "https://utlrtdwxjyjmlpzbyfgx.supabase.co")!
+    /// Replace with your project's anon key.
+    static let apiKey = "YOUR_SUPABASE_ANON_KEY"
+
+    /// Response structure returned by the Supabase auth endpoint.
+    private struct TokenResponse: Decodable { let access_token: String }
+
+    /// Sign in a user with email and password and return the access token.
+    static func signIn(email: String, password: String) async throws -> String {
+        let signInURL = url
+            .appendingPathComponent("auth")
+            .appendingPathComponent("v1")
+            .appendingPathComponent("token")
+            .appending(queryItems: [
+                URLQueryItem(name: "grant_type", value: "password")
+            ])
+
+        var request = URLRequest(url: signInURL)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue(apiKey, forHTTPHeaderField: "apikey")
+        let body = ["email": email, "password": password]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse,
+              http.statusCode == 200 else {
+            throw URLError(.badServerResponse)
+        }
+
+        return try JSONDecoder().decode(TokenResponse.self, from: data).access_token
+    }
+
+    /// Fetch all todos using the provided access token.
+    static func fetchTodos(accessToken: String) async throws -> [Todo] {
+        let todosURL = url
+            .appendingPathComponent("rest")
+            .appendingPathComponent("v1")
+            .appendingPathComponent("todos")
+
+        var request = URLRequest(url: todosURL)
+        request.httpMethod = "GET"
+        request.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.addValue(apiKey, forHTTPHeaderField: "apikey")
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse,
+              (200..<300).contains(http.statusCode) else {
+            throw URLError(.badServerResponse)
+        }
+
+        return try JSONDecoder().decode([Todo].self, from: data)
+    }
+}
+

--- a/Mojo/Supabase.swift
+++ b/Mojo/Supabase.swift
@@ -1,0 +1,9 @@
+import Foundation
+import Supabase
+
+// Configure the Supabase client used throughout the app.
+// Replace the placeholder key with your project's anon key.
+let supabase = SupabaseClient(
+    supabaseURL: URL(string: "https://utlrtdwxjyjmlpzbyfgx.supabase.co")!,
+    supabaseKey: "YOUR_SUPABASE_ANON_KEY"
+)

--- a/Mojo/Todo.swift
+++ b/Mojo/Todo.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct Todo: Identifiable, Decodable {
+    var id: Int
+    var title: String
+}


### PR DESCRIPTION
## Summary
- integrate Supabase client configuration
- provide simple Todo model
- implement login and logout UI with Supabase auth

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68509bcace20832b8b30926b579ff801