### PR TITLE
Add simple Supabase authentication

### DIFF
--- a/Mojo.xcodeproj/project.pbxproj
+++ b/Mojo.xcodeproj/project.pbxproj
@@ -111,8 +111,9 @@
 				B7DAB6BC2DFF75AB003C77AD /* Mojo */,
 			);
 			name = Mojo;
-			packageProductDependencies = (
-			);
+                       packageProductDependencies = (
+                               B7DAB72A2E00D7B4003C77AD /* Supabase */,
+                       );
 			productName = Mojo;
 			productReference = B7DAB6BA2DFF75AB003C77AD /* Mojo.app */;
 			productType = "com.apple.product-type.application";
@@ -134,8 +135,9 @@
 				B7DAB6CA2DFF75AD003C77AD /* MojoTests */,
 			);
 			name = MojoTests;
-			packageProductDependencies = (
-			);
+                       packageProductDependencies = (
+                               B7DAB72A2E00D7B4003C77AD /* Supabase */,
+                       );
 			productName = MojoTests;
 			productReference = B7DAB6C72DFF75AD003C77AD /* MojoTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -157,8 +159,9 @@
 				B7DAB6D42DFF75AD003C77AD /* MojoUITests */,
 			);
 			name = MojoUITests;
-			packageProductDependencies = (
-			);
+                       packageProductDependencies = (
+                               B7DAB72A2E00D7B4003C77AD /* Supabase */,
+                       );
 			productName = MojoUITests;
 			productReference = B7DAB6D12DFF75AD003C77AD /* MojoUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
@@ -561,6 +564,14 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCSwiftPackageProductDependency section */
+               B7DAB72A2E00D7B4003C77AD /* Supabase */ = {
+                       isa = XCSwiftPackageProductDependency;
+                       productName = Supabase;
+                       package = B7DAB7282E00D7B4003C77AD /* XCRemoteSwiftPackageReference "supabase-swift" */;
+               };
+/* End XCSwiftPackageProductDependency section */
 
 /* Begin XCRemoteSwiftPackageReference section */
 		B7DAB7282E00D7B4003C77AD /* XCRemoteSwiftPackageReference "supabase-swift" */ = {

--- a/Mojo/ContentView.swift
+++ b/Mojo/ContentView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct ContentView: View {
     @State var todos: [Todo] = []
+    @EnvironmentObject var sessionManager: SessionManager
 
     var body: some View {
         NavigationStack {
@@ -10,6 +11,11 @@ struct ContentView: View {
                 Text(todo.title)
             }
             .navigationTitle("Todos")
+            .toolbar {
+                Button("Sign Out") {
+                    Task { await signOut() }
+                }
+            }
             .task {
                 do {
                     todos = try await supabase.from("todos").select().execute().value
@@ -19,8 +25,18 @@ struct ContentView: View {
             }
         }
     }
+
+    @MainActor
+    private func signOut() async {
+        do {
+            try await supabase.auth.signOut()
+        } catch {
+            debugPrint("Sign out error: \(error)")
+        }
+    }
 }
 
 #Preview {
     ContentView()
+        .environmentObject(SessionManager())
 }

--- a/Mojo/ContentView.swift
+++ b/Mojo/ContentView.swift
@@ -1,17 +1,22 @@
-//
-//  ContentView.swift
-//  Mojo
-//
-//  Created by Tyler Bullock on 6/15/25.
-//
-
+import Supabase
 import SwiftUI
 
 struct ContentView: View {
+    @State var todos: [Todo] = []
+
     var body: some View {
-        NavigationView {
-            HabitTracker()
-                .navigationTitle("Mojo")
+        NavigationStack {
+            List(todos) { todo in
+                Text(todo.title)
+            }
+            .navigationTitle("Todos")
+            .task {
+                do {
+                    todos = try await supabase.from("todos").select().execute().value
+                } catch {
+                    debugPrint(error)
+                }
+            }
         }
     }
 }

--- a/Mojo/LoginView.swift
+++ b/Mojo/LoginView.swift
@@ -4,6 +4,7 @@ struct LoginView: View {
     @State private var email = ""
     @State private var password = ""
     @EnvironmentObject var sessionManager: SessionManager
+    @State private var loginError: String?
 
     var body: some View {
         VStack(spacing: 16) {
@@ -28,6 +29,11 @@ struct LoginView: View {
             .buttonStyle(.borderedProminent)
         }
         .padding()
+        .alert("Login Error", isPresented: .constant(loginError != nil), actions: {
+            Button("OK", role: .cancel) { loginError = nil }
+        }, message: {
+            if let loginError { Text(loginError) }
+        })
     }
 
     @MainActor
@@ -35,7 +41,7 @@ struct LoginView: View {
         do {
             try await supabase.auth.signIn(email: email, password: password)
         } catch {
-            print("Login error: \(error)")
+            loginError = error.localizedDescription
         }
     }
 }

--- a/Mojo/LoginView.swift
+++ b/Mojo/LoginView.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+struct LoginView: View {
+    @State private var email = ""
+    @State private var password = ""
+    @EnvironmentObject var sessionManager: SessionManager
+
+    var body: some View {
+        VStack(spacing: 16) {
+            TextField("Email", text: $email)
+                .textContentType(.emailAddress)
+                .autocapitalization(.none)
+                .keyboardType(.emailAddress)
+                .padding()
+                .background(Color(.secondarySystemBackground))
+                .cornerRadius(8)
+
+            SecureField("Password", text: $password)
+                .textContentType(.password)
+                .autocapitalization(.none)
+                .padding()
+                .background(Color(.secondarySystemBackground))
+                .cornerRadius(8)
+
+            Button("Sign In") {
+                Task { await signIn() }
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .padding()
+    }
+
+    @MainActor
+    private func signIn() async {
+        do {
+            try await supabase.auth.signIn(email: email, password: password)
+        } catch {
+            print("Login error: \(error)")
+        }
+    }
+}
+
+#Preview {
+    LoginView()
+        .environmentObject(SessionManager())
+}

--- a/Mojo/MojoApp.swift
+++ b/Mojo/MojoApp.swift
@@ -1,17 +1,13 @@
-//
-//  MojoApp.swift
-//  Mojo
-//
-//  Created by Tyler Bullock on 6/15/25.
-//
-
 import SwiftUI
 
 @main
 struct MojoApp: App {
+    @StateObject private var sessionManager = SessionManager()
+
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            RootView()
+                .environmentObject(sessionManager)
         }
     }
 }

--- a/Mojo/RootView.swift
+++ b/Mojo/RootView.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct RootView: View {
+    @EnvironmentObject var sessionManager: SessionManager
+
+    var body: some View {
+        Group {
+            if sessionManager.session == nil {
+                LoginView()
+            } else {
+                ContentView()
+            }
+        }
+    }
+}
+
+#Preview {
+    RootView()
+        .environmentObject(SessionManager())
+}

--- a/Mojo/SessionManager.swift
+++ b/Mojo/SessionManager.swift
@@ -1,0 +1,22 @@
+import Foundation
+import Supabase
+import SwiftUI
+
+@MainActor
+final class SessionManager: ObservableObject {
+    @Published var session: Session?
+
+    private var handleTask: Task<Void, Never>?
+
+    init() {
+        handleTask = Task {
+            for await (_, session) in supabase.auth.authStateChanges {
+                self.session = session
+            }
+        }
+    }
+
+    deinit {
+        handleTask?.cancel()
+    }
+}

--- a/Mojo/Supabase.swift
+++ b/Mojo/Supabase.swift
@@ -3,5 +3,5 @@ import Supabase
 
 let supabase = SupabaseClient(
     supabaseURL: URL(string: "https://utlrtdwxjyjmlpzbyfgx.supabase.co")!,
-    supabaseKey: "YOUR_SUPABASE_ANON_KEY"
+    supabaseKey: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InV0bHJ0ZHd4anlqbWxwemJ5Zmd4Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDkyNDAwMzAsImV4cCI6MjA2NDgxNjAzMH0.-tep6vw6CPMprmyAgE3MBE64cqAJl53H3LbTs-L6JLA"
 )

--- a/Mojo/Supabase.swift
+++ b/Mojo/Supabase.swift
@@ -1,0 +1,7 @@
+import Foundation
+import Supabase
+
+let supabase = SupabaseClient(
+    supabaseURL: URL(string: "https://utlrtdwxjyjmlpzbyfgx.supabase.co")!,
+    supabaseKey: "YOUR_SUPABASE_ANON_KEY"
+)

--- a/Mojo/Todo.swift
+++ b/Mojo/Todo.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct Todo: Identifiable, Decodable {
+    var id: Int
+    var title: String
+}

--- a/README.md
+++ b/README.md
@@ -46,3 +46,6 @@ Create `Mojo/Supabase.swift` with your project URL and anon key as shown in the 
 ### 3. Fetch Packages
 Open `Mojo.xcodeproj` in Xcode and resolve Swift Package dependencies to download the `supabase-swift` package.
 
+
+### 4. Run the App
+Open the project in Xcode, build and run. Sign in with your Supabase credentials on the login screen. Use the Sign Out button in the Todos list to end your session.

--- a/README.md
+++ b/README.md
@@ -39,3 +39,7 @@ Mojo is a habit tracking and personal development app built in **SwiftUI** for i
 ```bash
 git clone https://github.com/yourusername/mojo-ios.git
 cd mojo-ios
+
+### 2. Configure Supabase
+Create `Mojo/Supabase.swift` with your project URL and anon key as shown in the source.
+

--- a/README.md
+++ b/README.md
@@ -43,3 +43,6 @@ cd mojo-ios
 ### 2. Configure Supabase
 Create `Mojo/Supabase.swift` with your project URL and anon key as shown in the source.
 
+### 3. Fetch Packages
+Open `Mojo.xcodeproj` in Xcode and resolve Swift Package dependencies to download the `supabase-swift` package.
+


### PR DESCRIPTION
## Summary
- add Supabase client helper
- add login view and session manager
- show ContentView after signing in
- fetch todos from Supabase
- document how to configure Supabase

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6850a98c29a8832b91d112d919c46f51